### PR TITLE
Assume the last entry in args is eye position, carefully.

### DIFF
--- a/nndichromacy/models/encoders.py
+++ b/nndichromacy/models/encoders.py
@@ -27,11 +27,11 @@ class Encoder(nn.Module):
         #print("using new Encoder")
 
 
-    def forward(self, *args, data_key=None, eye_pos=None, shift=None, **kwargs):
+    def forward(self, *args, data_key=None, shift=None, **kwargs):
 
         x = self.core(args[0])
 
-        eye_pos, shift = None, None
+        eye_pos = None
         if len(args) > 2:
             if hasattr(args[-1], 'shape'):
                 if len(args[-1].shape) == 2:


### PR DESCRIPTION
It seemed that the code makes an assumption about `eye_pos` being the last entry in the `args`. I kept that logic the same, but the code could potentially result in an error. Imagine args have three entries but non of them are eye_pos. let's say the last entry is something that is 1-d (time stamps for instance). Then the line with `args[-1].shape[1] == 2` could potentially raise an error. The changes proposed takes the last entry that is 2-d and checks if it has 2 columns, and then takes that as `eye_pos`.